### PR TITLE
Use SF Symbols for actions

### DIFF
--- a/OmniToggl.omnifocusjs/manifest.json
+++ b/OmniToggl.omnifocusjs/manifest.json
@@ -6,9 +6,11 @@
   "description": "A collection of actions for starting Toggl from OmniFocus. See: https://github.com/benhughes/OmniToggl",
   "actions": [
     {
+      "image": "play.circle",
       "identifier": "startTogglTimer"
     },
     {
+      "image": "stop.circle",
       "identifier": "stopTogglTimer"
     }
   ],


### PR DESCRIPTION
[As per omni automation documentation](https://omni-automation.com/plugins/bundle.html) SF symbols might be used for MacOS >11 and iOS >14

>The image key has a value that is the name of the image file (with file extension) that is the toolbar icon for the action. OPTIONALLY (req: macOS 11/iOS 14/iPadOS 14): the value of this key can be the assigned name of a specified Apple [SF Symbols](https://developer.apple.com/sf-symbols/) character, such as: "newpaper.fill". For a complete catalog of SF Symbols characters, download the SF Symbols application from Apple.

I didn't test on older macOS but I assume that it will just show the default icon instead (the Kanban omnijs plugin uses SF symbols too); Choice of the symbols might be different, but those seemed most similar to start/stop; 
there exists a timer symbol but there is no parallel stop timer symbol. 