### PR TITLE
Pass .name instead of project.name to create a new project.

### DIFF
--- a/OmniToggl.omnifocusjs/Resources/common.js
+++ b/OmniToggl.omnifocusjs/Resources/common.js
@@ -123,7 +123,7 @@
   ) {
     const fetchRequest = new URL.FetchRequest();
     fetchRequest.bodyData = Data.fromString(
-      JSON.stringify({ active: true, project: { name } }),
+      JSON.stringify({ active: true, name }),
     );
     fetchRequest.method = 'POST';
     fetchRequest.headers = {


### PR DESCRIPTION
This might be a recent API change, however, now the request body expects a field called `name` instead of `project.name` to create a project: https://engineering.toggl.com/docs/api/projects#post-workspaceprojects